### PR TITLE
Eliminamos warning de foreach en admin_home.php

### DIFF
--- a/controller/admin_home.php
+++ b/controller/admin_home.php
@@ -487,7 +487,7 @@ class admin_home extends fs_controller
                {
                   $plugin['version_url'] = $ini_file['version_url'];
                }
-               else
+               elseif (is_array($this->download_list2) || is_object($this->download_list2))
                {
                   foreach($this->download_list2 as $ditem)
                   {


### PR DESCRIPTION
Al pasarle al foreach un parametro que no es array u objeto salta
warning. Se añade comprobación del parámetro antes de pasarlo al
foreach.