### PR TITLE
problema con XML y palabr YES/SI

### DIFF
--- a/base/fs_mysql.php
+++ b/base/fs_mysql.php
@@ -501,12 +501,14 @@ class fs_mysql
                            {
                               $consulta .= 'ALTER TABLE '.$table_name.' MODIFY `'.$col2['column_name'].'` '.$col2['data_type'];
                               
-                              if($col2['is_nullable'] == 'YES')
+                              if($col2['is_nullable'] == 'YES' || $col2['is_nullable'] == 'SI')
                               {
                                  $consulta .= ' NULL AUTO_INCREMENT;';
                               }
-                              else
+                              else if($col2['is_nullable'] == 'NO')
+			      {
                                  $consulta .= ' NOT NULL AUTO_INCREMENT;';
+			      }
                            }
                         }
                         else
@@ -516,11 +518,11 @@ class fs_mysql
                   
                   if($col2['is_nullable'] != $col['nulo'])
                   {
-                     if($col['nulo'] == 'YES')
+                     if($col['nulo'] == 'YES' || $col['nulo'] == 'SI')
                      {
                         $consulta .= 'ALTER TABLE '.$table_name.' MODIFY `'.$col['nombre'].'` '.$col['tipo'].' NULL;';
                      }
-                     else
+                     else if($col['nulo'] == 'NO')
                         $consulta .= 'ALTER TABLE '.$table_name.' MODIFY `'.$col['nombre'].'` '.$col['tipo'].' NOT NULL;';
                   }
                   
@@ -552,11 +554,11 @@ class fs_mysql
                {
                   $consulta .= " DEFAULT ".$col['defecto'].";";
                }
-               else if($col['nulo'] == 'YES')
+               else if($col['nulo'] == 'YES' || $col['nulo'] == 'SI')
                {
                   $consulta .= " DEFAULT NULL;";
                }
-               else
+               else if($col['nulo'] == 'NO')
                   $consulta .= ';';
             }
          }


### PR DESCRIPTION
Estaba recibiendo un extraño mensaje de error derivado de una tabla de un plugin que facturascripts intentaba cambiar constantemente al cargar el modelo.

El tema estaba en el fichero fs_mysql.php , se intentaba hacer un alter table derivado de que el permitir NULL variaba constantemente y luego se intentaba poner a default NULL.

Al final era porque había puesto en el XML en la parte de <NULO> "SI" y hay que poner "YES".

Lo que propongo son dos cosas:

1) Por un lado que se compare con "YES" y con "SI", ya que no es una cosa extraña y puede ocurrir más a menudo de lo que parece
2) Creo que la comparación no se está haciendo bien del todo, puesto que es "if column['is_nullable'] == YES" then... else...
y creo que se debería, o bien poner primero el if column['is_nullable'] == NO o bien en vez de un else un "else if column['is_nullable'] == NO" para que, en caso de que se ponga un valor erróneo que no se meta por esa línea forzando un alter que puede dar problemas. Si el usuario ha puesto <NULO>kk</NULO>, se metería por el NO.