### PR TITLE
bug al calcular el máximo para subir de un fichero

### DIFF
--- a/base/fs_controller.php
+++ b/base/fs_controller.php
@@ -1207,7 +1207,7 @@ class fs_controller
    {
       $max = intval( ini_get('post_max_size') );
       
-      if( intval(ini_get('upload_max_filesize')) > $max )
+      if( intval(ini_get('upload_max_filesize')) < $max )
       {
          $max = intval(ini_get('upload_max_filesize'));
       }


### PR DESCRIPTION
Al calcular el tamaño máximo a subir que acepta el servidor, se debe tener en cuenta la cifra MENOR, no la mayor, ya que es la que limita el tamaño máximo. Si se tiene puesto en max_post = 32M y en max_upload_file = 2M, el método devuelve que el tamaño máximo que acepta el servidor es 32M y en realidad el tamaño máximo que acepta es de 2M.