### PR TITLE
Usar ORDER BY name ASC en todas las consultas

### DIFF
--- a/model/fs_extension.php
+++ b/model/fs_extension.php
@@ -183,7 +183,7 @@ class fs_extension extends fs_model
    {
       $elist = array();
       
-      $data = $this->db->select("SELECT * FROM ".$this->table_name." ORDER BY text ASC;");
+      $data = $this->db->select("SELECT * FROM ".$this->table_name." ORDER BY name ASC;");
       if($data)
       {
          foreach($data as $d)


### PR DESCRIPTION
Sino podemos re-ordenar la lista que nos devuelve usando el campo name, no tenemos forma de que allí donde necesitemos cargar CSS o JS se carguen con el orden que necesitamos.

Si se ordena por text, se ordena por el texto que insertará en la página, que será un orden bastante "aleatorio" en realidad, en cambio si se ordena por name, podemos reordenarlos, por ejemplo:

"01-css-complemento-X"
"02-css-complemento-Y"
"03-js-complemento-X"
"04-js-complemento-Y"

Sin este cambio tonto, no tenemos forma de hacer que el uso de shared_extensions reemplace el uso real de usar las etiquetas para cargar CSS o JS desde la vista, porqué perdemos totalmente el control del orden necesario.