### PR TITLE
 FALLO falta un ; (AH01215: PHP Parse error:  syntax error, unexpected '}' in /model/core/pais.php on line 333)

### DIFF
--- a/model/core/pais.php
+++ b/model/core/pais.php
@@ -329,7 +329,7 @@ class pais extends \fs_model
               . " ('YEM','YE','Yemen'),"
               . " ('DJI','DJ','Yibuti'),"
               . " ('ZMB','ZM','Zambia'),"
-              . " ('ZWE','ZW','Zimbabue'),"
+              . " ('ZWE','ZW','Zimbabue'),";
    }
    
    /**


### PR DESCRIPTION
Al actualizar dará error en la línea 333, dado que falta un ; en /model/core/pais.php  línea 332

(AH01215: PHP Parse error:  syntax error, unexpected '}' in /home/irepair/web/irepaironline.es/public_html/controlgestion/model/core/pais.php on line 333)