### PR TITLE
Update base.js

### DIFF
--- a/view/js/base.js
+++ b/view/js/base.js
@@ -217,7 +217,8 @@ $(document).ready(function() {
       if(event.which === 1)
       {
          var target = $(this).attr('target');
-         if(typeof target !== typeof undefined && target !== false)
+         var href = $(this).attr('href');
+         if(typeof target !== typeof undefined && target !== false && typeof href !== typeof undefined && href !== false)
          {
             if(target == '_blank')
             {
@@ -228,7 +229,7 @@ $(document).ready(function() {
                parent.document.location = $(this).attr("href");
             }
          }
-         else
+         else if (typeof href !== typeof undefined && href !== false)
          {
             parent.document.location = $(this).attr("href");
          }


### PR DESCRIPTION
En el caso que clickableRow no tenga href, se comportará simplemente como un estilo CSS.