### PR TITLE
Reemplazo $_POST, $_GET, $_REQUEST y $_COOKIE por filter_input()

### DIFF
--- a/base/fs_controller.php
+++ b/base/fs_controller.php
@@ -119,10 +119,11 @@ class fs_controller {
     */
    public $template;
 
+  
    /**
     * Esta variable contiene el texto enviado como parámetro query por cualquier formulario,
-    * es decir, se corresponde con filter_input(INPUT_POST, 'query']
-    * @var type 
+    * es decir, se corresponde con $_POST['query']
+    * @var string
     */
    public $query;
 
@@ -315,8 +316,8 @@ class fs_controller {
     * Muestra al usuario un mensaje de error
     * @param string $msg el mensaje a mostrar
     */
-   public function new_error_msg($msg = FALSE, $tipo = 'error', $alerta = FALSE, $guardar = TRUE) {
-      if ($msg) {
+   public function new_error_msg($msg = false, $tipo = 'error', $alerta = false, $guardar = true) {
+   	if ($msg!== false) {
          $this->errors[] = str_replace("\n", ' ', $msg);
 
          if ($guardar) {
@@ -357,11 +358,15 @@ class fs_controller {
       return $this->errors;
    }
 
+
    /**
     * Muestra un mensaje al usuario
-    * @param type $msg mensaje a mostrar
+    * @param string $msg
+    * @param boolean $save
+    * @param string $tipo
+    * @param boolean $alerta
     */
-   public function new_message($msg = FALSE, $save = FALSE, $tipo = 'msg', $alerta = FALSE) {
+   public function new_message($msg = '', $save = FALSE, $tipo = 'msg', $alerta = FALSE) {
       if ($msg) {
          $this->messages[] = str_replace("\n", ' ', $msg);
 

--- a/base/fs_model.php
+++ b/base/fs_model.php
@@ -206,7 +206,7 @@ abstract class fs_model {
    /**
     * Transforma una variable en una cadena de texto válida para ser
     * utilizada en una consulta SQL.
-    * @param type $v
+    * @param object $v
     * @return string
     */
    public function var2str($v) {

--- a/controller/admin_home.php
+++ b/controller/admin_home.php
@@ -492,7 +492,7 @@ class admin_home extends fs_controller {
 
    /**
     * Elimina recursivamente un directorio
-    * @param type $dir
+    * @param string $dir
     * @return type
     */
    private function del_tree($dir) {

--- a/controller/admin_user.php
+++ b/controller/admin_user.php
@@ -59,15 +59,15 @@ class admin_user extends fs_controller {
             $this->allow_delete = FALSE;
          }
 
-         if (filter_input(INPUT_POST, (string)'nnombre')) {
+         if (filter_input(INPUT_POST, 'nnombre')) {
             /// Nuevo empleado
             $age0 = new agente();
             $age0->codagente = $age0->get_new_codigo();
-            $age0->nombre = filter_input(INPUT_POST, (string)'nnombre');
-            $age0->apellidos = filter_input(INPUT_POST, (string)'napellidos');
-            $age0->dnicif = filter_input(INPUT_POST, (string)'ndnicif');
-            $age0->telefono = filter_input(INPUT_POST, (string)'ntelefono');
-            $age0->email = strtolower(filter_input(INPUT_POST, (string)'nemail'));
+            $age0->nombre = filter_input(INPUT_POST, 'nnombre');
+            $age0->apellidos = filter_input(INPUT_POST, 'napellidos');
+            $age0->dnicif = filter_input(INPUT_POST, 'ndnicif');
+            $age0->telefono = filter_input(INPUT_POST, 'ntelefono');
+            $age0->email = strtolower(filter_input(INPUT_POST, 'nemail'));
 
             if (!$this->user->admin) {
                $this->new_error_msg('Solamente un administrador puede crear y asignar un empleado desde aquí.');
@@ -82,16 +82,16 @@ class admin_user extends fs_controller {
             } else
                $this->new_error_msg("¡Imposible guardar el agente!");
          }
-         else if (filter_input(INPUT_POST, (string)'spassword') OR filter_input(INPUT_POST, (string)'scodagente') OR filter_input(INPUT_POST, (string)'sadmin')) {
+         else if (filter_input(INPUT_POST, 'spassword') OR filter_input(INPUT_POST, 'scodagente') OR filter_input(INPUT_POST, 'sadmin')) {
             $this->modificar_user();
-         } else if (filter_input(INPUT_POST, (string)'senabled')) {
+         } else if (filter_input(INPUT_POST, 'senabled')) {
             if (!$this->user->admin) {
                $this->new_error_msg('Solamente un administrador puede activar o desactivar a un Usuario.');
             } else if ($this->user->nick == $this->suser->nick) {
                $this->new_error_msg('No se permite Activar/Desactivar a uno mismo.');
             } else {
                // Un usuario no se puede Activar/Desactivar a el mismo.
-               $this->suser->enabled = filter_input(INPUT_POST, (string)'senabled');
+               $this->suser->enabled = filter_input(INPUT_POST, 'senabled');
 
                if ($this->suser->save()) {
                   if ($this->suser->enabled) {
@@ -278,9 +278,9 @@ class admin_user extends fs_controller {
       } else {
          $user_no_more_admin = FALSE;
          $error = FALSE;
-         if (filter_input(INPUT_POST, (string)'spassword') != '') {
-            if (filter_input(INPUT_POST, (string)'spassword') == filter_input(INPUT_POST, (string)'spassword2')) {
-               if ($this->suser->set_password(filter_input(INPUT_POST, (string)'spassword'))) {
+         if (filter_input(INPUT_POST, 'spassword') != '') {
+            if (filter_input(INPUT_POST, 'spassword') == filter_input(INPUT_POST, 'spassword2')) {
+               if ($this->suser->set_password(filter_input(INPUT_POST, 'spassword'))) {
                   $this->new_message('Se ha cambiado la contraseña del usuario ' . $this->suser->nick, TRUE, 'login', TRUE);
                }
             } else {
@@ -289,14 +289,14 @@ class admin_user extends fs_controller {
             }
          }
 
-         if (filter_input(INPUT_POST, (string)'email')) {
-            $this->suser->email = strtolower(filter_input(INPUT_POST, (string)'email'));
+         if (filter_input(INPUT_POST, 'email')) {
+            $this->suser->email = strtolower(filter_input(INPUT_POST, 'email'));
          }
 
-         if (filter_input(INPUT_POST, (string)'scodagente')) {
+         if (filter_input(INPUT_POST, 'scodagente')) {
             $this->suser->codagente = NULL;
-            if (filter_input(INPUT_POST, (string)'scodagente') != '') {
-               $this->suser->codagente = filter_input(INPUT_POST, (string)'scodagente');
+            if (filter_input(INPUT_POST, 'scodagente') != '') {
+               $this->suser->codagente = filter_input(INPUT_POST, 'scodagente');
             }
          }
 
@@ -312,20 +312,20 @@ class admin_user extends fs_controller {
                 * Si un usuario es administrador y deja de serlo, hay que darle acceso
                 * a algunas páginas, en caso contrario no podrá continuar
                 */
-               if ($this->suser->admin AND ! filter_input(INPUT_POST, (string)'sadmin')) {
+               if ($this->suser->admin AND ! filter_input(INPUT_POST, 'sadmin')) {
                   $user_no_more_admin = TRUE;
                }
-               $this->suser->admin = filter_input(INPUT_POST, (string)'sadmin');
+               $this->suser->admin = filter_input(INPUT_POST, 'sadmin');
             }
          }
 
          $this->suser->fs_page = NULL;
-         if (filter_input(INPUT_POST, (string)'udpage')) {
-            $this->suser->fs_page = filter_input(INPUT_POST, (string)'udpage');
+         if (filter_input(INPUT_POST, 'udpage')) {
+            $this->suser->fs_page = filter_input(INPUT_POST, 'udpage');
          }
 
-         if (filter_input(INPUT_POST, (string)'css')) {
-            $this->suser->css = filter_input(INPUT_POST, (string)'css');
+         if (filter_input(INPUT_POST, 'css')) {
+            $this->suser->css = filter_input(INPUT_POST, 'css');
          }
 
          if ($error) {
@@ -342,8 +342,8 @@ class admin_user extends fs_controller {
                    * si ya estaba en la base de datos. Eso lo hace el modelo.
                    */
                   $a = new fs_access(array('fs_user' => $this->suser->nick, 'fs_page' => $p->name, 'allow_delete' => FALSE));
-                  if (filter_input(INPUT_POST, (string)'allow_delete')) {
-                     $a->allow_delete = in_array($p->name, filter_input(INPUT_POST, (string)'allow_delete'));
+                  if (filter_input(INPUT_POST, 'allow_delete')) {
+                     $a->allow_delete = in_array($p->name, filter_input(INPUT_POST, 'allow_delete'));
                   }
 
                   if ($user_no_more_admin) {
@@ -352,13 +352,13 @@ class admin_user extends fs_controller {
                       * a algunas páginas, en caso contrario no podrá continuar.
                       */
                      $a->save();
-                  } else if (!filter_input(INPUT_POST, (string)'enabled')) {
+                  } else if (!filter_input(INPUT_POST, 'enabled')) {
                      /**
                       * No se ha marcado ningún checkbox de autorizado, así que eliminamos el acceso
                       * a todas las páginas. Una a una.
                       */
                      $a->delete();
-                  } else if (in_array($p->name, filter_input(INPUT_POST, (string)'enabled'))) {
+                  } else if (in_array($p->name, filter_input(INPUT_POST, 'enabled'))) {
                      /// la página ha sido marcada como autorizada.
                      $a->save();
 

--- a/controller/admin_users.php
+++ b/controller/admin_users.php
@@ -38,11 +38,11 @@ class admin_users extends fs_controller {
       $this->agente = new agente();
       $this->rol = new fs_rol();
 
-      if (filter_input(INPUT_POST, (string)'nnick')) {
+      if (filter_input(INPUT_POST, 'nnick')) {
          $this->add_user();
       } else if (filter_input(INPUT_GET, (string)'delete')) {
          $this->delete_user();
-      } else if (filter_input(INPUT_POST, (string)'nrol')) {
+      } else if (filter_input(INPUT_POST, 'nrol')) {
          $this->add_rol();
       } else if (filter_input(INPUT_GET, (string)'delete_rol')) {
          $this->delete_rol();
@@ -54,21 +54,21 @@ class admin_users extends fs_controller {
    }
 
    private function add_user() {
-      $nu = $this->user->get(filter_input(INPUT_POST, (string)'nnick'));
+      $nu = $this->user->get(filter_input(INPUT_POST, 'nnick'));
       if ($nu) {
          $this->new_error_msg('El usuario <a href="' . $nu->url() . '">ya existe</a>.');
       } else if (!$this->user->admin) {
          $this->new_error_msg('Solamente un administrador puede crear usuarios.', TRUE, 'login', TRUE);
       } else {
          $nu = new fs_user();
-         $nu->nick = filter_input(INPUT_POST, (string)'nnick');
-         $nu->email = strtolower(filter_input(INPUT_POST, (string)'nemail'));
+         $nu->nick = filter_input(INPUT_POST, 'nnick');
+         $nu->email = strtolower(filter_input(INPUT_POST, 'nemail'));
 
-         if ($nu->set_password(filter_input(INPUT_POST, (string)'npassword'))) {
-            $nu->admin = filter_input(INPUT_POST, (string)'nadmin');
-            if (filter_input(INPUT_POST, (string)'ncodagente')) {
-               if (filter_input(INPUT_POST, (string)'ncodagente') != '') {
-                  $nu->codagente = filter_input(INPUT_POST, (string)'ncodagente');
+         if ($nu->set_password(filter_input(INPUT_POST, 'npassword'))) {
+            $nu->admin = filter_input(INPUT_POST, 'nadmin');
+            if (filter_input(INPUT_POST, 'ncodagente')) {
+               if (filter_input(INPUT_POST, 'ncodagente') != '') {
+                  $nu->codagente = filter_input(INPUT_POST, 'ncodagente');
                }
             }
 
@@ -76,8 +76,8 @@ class admin_users extends fs_controller {
                $this->new_message('Usuario ' . $nu->nick . ' creado correctamente.', TRUE, 'login', TRUE);
 
                /// algún rol marcado
-               if (!$nu->admin AND filter_input(INPUT_POST, (string)'roles')) {
-                  foreach (filter_input(INPUT_POST, (string)'roles') as $codrol) {
+               if (!$nu->admin AND filter_input(INPUT_POST, 'roles')) {
+                  foreach (filter_input(INPUT_POST, 'roles') as $codrol) {
                      $rol = $this->rol->get($codrol);
                      if ($rol) {
                         $fru = new fs_rol_user();
@@ -121,8 +121,8 @@ class admin_users extends fs_controller {
    }
 
    private function add_rol() {
-      $this->rol->codrol = filter_input(INPUT_POST, (string)'nrol');
-      $this->rol->descripcion = filter_input(INPUT_POST, (string)'descripcion');
+      $this->rol->codrol = filter_input(INPUT_POST, 'nrol');
+      $this->rol->descripcion = filter_input(INPUT_POST, 'descripcion');
 
       if ($this->rol->save()) {
          $this->new_message('Datos guardados correctamente.');

--- a/model/core/fs_user.php
+++ b/model/core/fs_user.php
@@ -46,7 +46,7 @@ class fs_user extends \fs_model {
 
    /**
     * Email del usuario.
-    * @var type 
+    * @var  string 
     */
    public $email;
 
@@ -62,7 +62,7 @@ class fs_user extends \fs_model {
    /**
     * TRUE -> el usuario ha iniciado sesión
     * No se guarda en la base de datos
-    * @var type 
+    * @var boolean 
     */
    public $logged_on;
 

--- a/model/fs_access.php
+++ b/model/fs_access.php
@@ -40,7 +40,7 @@ class fs_access extends fs_model {
 
    /**
     * Otorga permisos al usuario a eliminar elementos en la página.
-    * @var type 
+    * @var boolean 
     */
    public $allow_delete;
 

--- a/model/fs_log.php
+++ b/model/fs_log.php
@@ -36,7 +36,7 @@ class fs_log extends fs_model {
 
    /**
     * Texto del log. Sin longitud máxima.
-    * @var type text
+    * @var string 
     */
    public $detalle;
    public $fecha;

--- a/view/index.html
+++ b/view/index.html
@@ -59,13 +59,13 @@
                         </li>
                      </ul>
                   </li>
-                  {if="filter_input(INPUT_GET, (string)'page')"}
+                  {if="filter_input(INPUT_GET, 'page')"}
                   <li>
                      <b>¿Eres programador y estas intentando hacer un plugin?</b>
                      <ul>
                         <li>
                            Entonces te comento que lo que ha pasado es que no encuentro
-                           el archivo <b>{filter_input(INPUT_GET, (string)'page')}.php</b>, que debería estar en
+                           el archivo <b>{function="filter_input(INPUT_GET, 'page')"}.php</b>, que debería estar en
                            el directorio <b>controller</b> de tu plugin.
                         </li>
                      </ul>


### PR DESCRIPTION
Se han reemplazado todas las referencias a $_POST, $_GET, $_REQUEST y $_COOKIE con la función filter_input() y filter_input_array(), se ha tenido especial cuidado con las comprobaciones mediante función isset(), ya que es incompatible con filter_input(), se ha probado la ejecución del código sobre instalación limpia del núcleo.